### PR TITLE
Removes extras closing footer tag (and reformats because VS Code)

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Landing Page</title>
-    <link rel="icon" href="icon.svg"/>
+    <link rel="icon" href="icon.svg" />
     <link rel="stylesheet" href="style.css">
 </head>
 
@@ -37,7 +37,9 @@
                 <img src="https://picsum.photos/300/300.webp?cb=1" alt="" class="card-image">
                 <div class="card-body ">
                     <h3 class="card-title ">Blurb one</h3>
-                    <p class="card-text ">A blurb is a brief promotional statement that appears on the cover or jacket of a book, usually written by another author or a reviewer. It's meant to entice potential readers to pick up the book and read it.</p>
+                    <p class="card-text ">A blurb is a brief promotional statement that appears on the cover or jacket
+                        of a book, usually written by another author or a reviewer. It's meant to entice potential
+                        readers to pick up the book and read it.</p>
                 </div>
             </button>
 
@@ -45,7 +47,8 @@
                 <img src="https://picsum.photos/300/300.webp?cb=2" alt="" class="card-image ">
                 <div class="card-body ">
                     <h3 class="card-title ">Second blurb</h3>
-                    <p class="card-text ">Blurbs can also be used in other forms of media, such as movies or music albums, to provide a quick summary of the content and entice people to watch or listen.</p>
+                    <p class="card-text ">Blurbs can also be used in other forms of media, such as movies or music
+                        albums, to provide a quick summary of the content and entice people to watch or listen.</p>
                 </div>
             </button>
 
@@ -53,16 +56,17 @@
                 <img src="https://picsum.photos/300/300.webp?cb=3" alt="" class="card-image ">
                 <div class="card-body ">
                     <h3 class="card-title ">The final blurb</h3>
-                    <p class="card-text ">While blurbs can be helpful in promoting a book or other creative work, they can also be controversial. Some authors feel uncomfortable asking others to write blurbs for them, and there have been cases of fake blurbs or blurbs that exaggerate the quality of the work.</p>
+                    <p class="card-text ">While blurbs can be helpful in promoting a book or other creative work, they
+                        can also be controversial. Some authors feel uncomfortable asking others to write blurbs for
+                        them, and there have been cases of fake blurbs or blurbs that exaggerate the quality of the
+                        work.</p>
                 </div>
             </button>
 
         </div>
 
         <footer class="footer ">
-        <p> &copy;2023 All rights reserved.</p>
-
-        </footer>
+            <p> &copy;2023 All rights reserved.</p>
         </footer>
 
     </div>


### PR DESCRIPTION
Noticed there was an extra closing `footer` tag, so removed it (and VS Code did it's thing and reformatted all the things).